### PR TITLE
fix: add missing yargs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,11 @@
     "test": "test"
   },
   "dependencies": {
-    "debug": "^4.1.1",
     "axios": "^0.19.0",
+    "debug": "^4.1.1",
     "geoip-lite": "^1.3.7",
-    "traceroute": "^1.0.0"
+    "traceroute": "^1.0.0",
+    "yargs": "^16.0.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.5.0",


### PR DESCRIPTION
`npx @tgwf/greentrace-cli` errors with
```
npx: installed 34 in 4.228s
Cannot find module 'yargs'
Require stack:
- /Users/j/.npm/_npx/3074/lib/node_modules/@tgwf/greentrace-cli/bin/greentrace.js
```